### PR TITLE
Refactor compiler skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install -y --fix-missing \
     curl \
     device-tree-compiler \
     lcov \
-    nano
+    nano \
+    valgrind
 
 # Install RISC-V Toolchain
 WORKDIR /tmp

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Based on https://stackoverflow.com/a/52036564 which is well worth reading!
 
-CXXFLAGS += -std=c++20 -W -Wall -g -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -fsanitize=address -static-libasan -O0 -rdynamic --coverage -I include
+CXXFLAGS += -std=c++20 -W -Wall -g -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -O0 -rdynamic --coverage -I include
 
 SOURCES := $(wildcard src/*.cpp)
 DEPENDENCIES := $(patsubst src/%.cpp,build/%.d,$(SOURCES))

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Based on https://stackoverflow.com/a/52036564 which is well worth reading!
 
-CXXFLAGS += -std=c++20 -W -Wall -g -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -O0 -rdynamic --coverage -I include
+CXXFLAGS += -std=c++20 -W -Wall -g -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -fsanitize=address -static-libasan -O0 -rdynamic --coverage -I include
 
 SOURCES := $(wildcard src/*.cpp)
 DEPENDENCIES := $(patsubst src/%.cpp,build/%.d,$(SOURCES))

--- a/debugging/example-backtrace-3.cpp
+++ b/debugging/example-backtrace-3.cpp
@@ -2,9 +2,9 @@
 #include <iostream>
 #include <vector>
 
-const char *ARRAY_OF_NUMBERS[] = { "1", "2" , "99" };
+const char* ARRAY_OF_NUMBERS[] = { "1", "2" , "99" };
 
-static int process_arguments(int argc, const char *argv[])
+static int process_arguments(int argc, const char* argv[])
 {
   std::vector<int> numbers(argc - 1);
   for (int i = 1 ; i < argc ; i++) {

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -13,4 +13,4 @@
 #include "ast_constant.hpp"
 #include "ast_context.hpp"
 
-extern ast::Node* ParseAST(std::string file_name);
+ast::NodePtr ParseAST(std::string file_name);

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -13,4 +13,4 @@
 #include "ast_constant.hpp"
 #include "ast_context.hpp"
 
-extern AST::Node* ParseAST(std::string file_name);
+extern ast::Node* ParseAST(std::string file_name);

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -13,4 +13,4 @@
 #include "ast_constant.hpp"
 #include "ast_context.hpp"
 
-extern Node *ParseAST(std::string file_name);
+extern AST::Node* ParseAST(std::string file_name);

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_HPP
-#define AST_HPP
+#pragma once
 
 #include <iostream>
 #include <string>
@@ -15,5 +14,3 @@
 #include "ast_context.hpp"
 
 extern Node *ParseAST(std::string file_name);
-
-#endif

--- a/include/ast_constant.hpp
+++ b/include/ast_constant.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_CONSTANT_HPP
-#define AST_CONSTANT_HPP
+#pragma once
 
 #include "ast_node.hpp"
 
@@ -14,5 +13,3 @@ public:
     void EmitRISC(std::ostream &stream, Context &context) const override;
     void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_constant.hpp
+++ b/include/ast_constant.hpp
@@ -2,6 +2,8 @@
 
 #include "ast_node.hpp"
 
+namespace AST {
+
 class IntConstant : public Node
 {
 private:
@@ -10,6 +12,8 @@ private:
 public:
     IntConstant(int value) : value_(value) {}
 
-    void EmitRISC(std::ostream &stream, Context &context) const override;
-    void Print(std::ostream &stream) const override;
+    void EmitRISC(std::ostream& stream, Context& context) const override;
+    void Print(std::ostream& stream) const override;
 };
+
+} // namespace AST

--- a/include/ast_constant.hpp
+++ b/include/ast_constant.hpp
@@ -2,7 +2,7 @@
 
 #include "ast_node.hpp"
 
-namespace AST {
+namespace ast {
 
 class IntConstant : public Node
 {
@@ -16,4 +16,4 @@ public:
     void Print(std::ostream& stream) const override;
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_context.hpp
+++ b/include/ast_context.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_CONTEXT_HPP
-#define AST_CONTEXT_HPP
+#pragma once
 
 // An object of class Context is passed between AST nodes during compilation.
 // This can be used to pass around information about what's currently being
@@ -8,5 +7,3 @@ class Context
 {
     /* TODO decide what goes inside here */
 };
-
-#endif

--- a/include/ast_context.hpp
+++ b/include/ast_context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+namespace AST {
 // An object of class Context is passed between AST nodes during compilation.
 // This can be used to pass around information about what's currently being
 // compiled (e.g. function scope and variable names).
@@ -7,3 +8,5 @@ class Context
 {
     /* TODO decide what goes inside here */
 };
+
+} // namespace AST

--- a/include/ast_context.hpp
+++ b/include/ast_context.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-namespace AST {
-// An object of class Context is passed between AST nodes during compilation.
+namespace ast {
+// An object of class Context is passed between ast nodes during compilation.
 // This can be used to pass around information about what's currently being
 // compiled (e.g. function scope and variable names).
 class Context
@@ -9,4 +9,4 @@ class Context
     /* TODO decide what goes inside here */
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_direct_declarator.hpp
+++ b/include/ast_direct_declarator.hpp
@@ -2,17 +2,18 @@
 
 #include "ast_node.hpp"
 
+namespace AST {
+
 class DirectDeclarator : public Node
 {
 private:
-    Node *identifier_;
+    NodePtr identifier_;
 
 public:
-    DirectDeclarator(Node *identifier) : identifier_(identifier){};
-    ~DirectDeclarator()
-    {
-        delete identifier_;
-    };
-    void EmitRISC(std::ostream &stream, Context &context) const override;
-    void Print(std::ostream &stream) const override;
+    DirectDeclarator(Node* identifier) : identifier_(identifier){};
+
+    void EmitRISC(std::ostream& stream, Context& context) const override;
+    void Print(std::ostream& stream) const override;
 };
+
+} // namespace AST

--- a/include/ast_direct_declarator.hpp
+++ b/include/ast_direct_declarator.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_DIRECT_DECLARATOR_HPP
-#define AST_DIRECT_DECLARATOR_HPP
+#pragma once
 
 #include "ast_node.hpp"
 
@@ -17,5 +16,3 @@ public:
     void EmitRISC(std::ostream &stream, Context &context) const override;
     void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_direct_declarator.hpp
+++ b/include/ast_direct_declarator.hpp
@@ -10,7 +10,7 @@ private:
     NodePtr identifier_;
 
 public:
-    DirectDeclarator(Node* identifier) : identifier_(identifier){};
+    DirectDeclarator(NodePtr identifier) : identifier_(std::move(identifier)){};
 
     void EmitRISC(std::ostream& stream, Context& context) const override;
     void Print(std::ostream& stream) const override;

--- a/include/ast_direct_declarator.hpp
+++ b/include/ast_direct_declarator.hpp
@@ -2,7 +2,7 @@
 
 #include "ast_node.hpp"
 
-namespace AST {
+namespace ast {
 
 class DirectDeclarator : public Node
 {
@@ -16,4 +16,4 @@ public:
     void Print(std::ostream& stream) const override;
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_function_definition.hpp
+++ b/include/ast_function_definition.hpp
@@ -1,22 +1,22 @@
 #pragma once
 
 #include "ast_node.hpp"
+#include "ast_type_specifier.hpp"
+
+namespace AST {
 
 class FunctionDefinition : public Node
 {
 private:
-    Node *declaration_specifiers_;
-    Node *declarator_;
-    Node *compound_statement_;
+    const TypeSpecifier declaration_specifiers_;
+    NodePtr declarator_;
+    NodePtr compound_statement_;
 
 public:
-    FunctionDefinition(Node *declaration_specifiers, Node *declarator, Node *compound_statement) : declaration_specifiers_(declaration_specifiers), declarator_(declarator), compound_statement_(compound_statement){};
-    ~FunctionDefinition()
-    {
-        delete declaration_specifiers_;
-        delete declarator_;
-        delete compound_statement_;
-    };
-    void EmitRISC(std::ostream &stream, Context &context) const override;
-    void Print(std::ostream &stream) const override;
+    FunctionDefinition(TypeSpecifier declaration_specifiers, Node* declarator, Node* compound_statement) : declaration_specifiers_(declaration_specifiers), declarator_(declarator), compound_statement_(compound_statement){};
+
+    void EmitRISC(std::ostream& stream, Context& context) const override;
+    void Print(std::ostream& stream) const override;
 };
+
+} // namespace AST

--- a/include/ast_function_definition.hpp
+++ b/include/ast_function_definition.hpp
@@ -3,7 +3,7 @@
 #include "ast_node.hpp"
 #include "ast_type_specifier.hpp"
 
-namespace AST {
+namespace ast {
 
 class FunctionDefinition : public Node
 {
@@ -19,4 +19,4 @@ public:
     void Print(std::ostream& stream) const override;
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_function_definition.hpp
+++ b/include/ast_function_definition.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_FUNCTION_DEFINITION_HPP
-#define AST_FUNCTION_DEFINITION_HPP
+#pragma once
 
 #include "ast_node.hpp"
 
@@ -21,5 +20,3 @@ public:
     void EmitRISC(std::ostream &stream, Context &context) const override;
     void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_function_definition.hpp
+++ b/include/ast_function_definition.hpp
@@ -13,7 +13,7 @@ private:
     NodePtr compound_statement_;
 
 public:
-    FunctionDefinition(TypeSpecifier declaration_specifiers, Node* declarator, Node* compound_statement) : declaration_specifiers_(declaration_specifiers), declarator_(declarator), compound_statement_(compound_statement){};
+    FunctionDefinition(TypeSpecifier declaration_specifiers, NodePtr declarator, NodePtr compound_statement) : declaration_specifiers_(declaration_specifiers), declarator_(std::move(declarator)), compound_statement_(std::move(compound_statement)){};
 
     void EmitRISC(std::ostream& stream, Context& context) const override;
     void Print(std::ostream& stream) const override;

--- a/include/ast_identifier.hpp
+++ b/include/ast_identifier.hpp
@@ -2,6 +2,8 @@
 
 #include "ast_node.hpp"
 
+namespace AST {
+
 class Identifier : public Node
 {
 private:
@@ -9,7 +11,9 @@ private:
 
 public:
     Identifier(std::string identifier) : identifier_(identifier){};
-    ~Identifier(){};
-    void EmitRISC(std::ostream &stream, Context &context) const override;
-    void Print(std::ostream &stream) const override;
+
+    void EmitRISC(std::ostream& stream, Context& context) const override;
+    void Print(std::ostream& stream) const override;
 };
+
+} // namespace AST

--- a/include/ast_identifier.hpp
+++ b/include/ast_identifier.hpp
@@ -2,7 +2,7 @@
 
 #include "ast_node.hpp"
 
-namespace AST {
+namespace ast {
 
 class Identifier : public Node
 {
@@ -16,4 +16,4 @@ public:
     void Print(std::ostream& stream) const override;
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_identifier.hpp
+++ b/include/ast_identifier.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_IDENTIFIER_HPP
-#define AST_IDENTIFIER_HPP
+#pragma once
 
 #include "ast_node.hpp"
 
@@ -14,5 +13,3 @@ public:
     void EmitRISC(std::ostream &stream, Context &context) const override;
     void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_identifier.hpp
+++ b/include/ast_identifier.hpp
@@ -10,7 +10,7 @@ private:
     std::string identifier_;
 
 public:
-    Identifier(std::string identifier) : identifier_(identifier){};
+    Identifier(std::string identifier) : identifier_(std::move(identifier)){};
 
     void EmitRISC(std::ostream& stream, Context& context) const override;
     void Print(std::ostream& stream) const override;

--- a/include/ast_jump_statement.hpp
+++ b/include/ast_jump_statement.hpp
@@ -2,18 +2,18 @@
 
 #include "ast_node.hpp"
 
+namespace AST {
+
 class ReturnStatement : public Node
 {
 private:
-    Node *expression_;
+    NodePtr expression_;
 
 public:
-    ReturnStatement(Node *expression) : expression_(expression) {}
-    ~ReturnStatement()
-    {
-        delete expression_;
-    };
+    ReturnStatement(Node* expression) : expression_(expression) {}
 
-    void EmitRISC(std::ostream &stream, Context &context) const override;
-    void Print(std::ostream &stream) const override;
+    void EmitRISC(std::ostream& stream, Context& context) const override;
+    void Print(std::ostream& stream) const override;
 };
+
+} // namespace AST

--- a/include/ast_jump_statement.hpp
+++ b/include/ast_jump_statement.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_JUMP_STATEMENT_HPP
-#define AST_JUMP_STATEMENT_HPP
+#pragma once
 
 #include "ast_node.hpp"
 
@@ -18,5 +17,3 @@ public:
     void EmitRISC(std::ostream &stream, Context &context) const override;
     void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_jump_statement.hpp
+++ b/include/ast_jump_statement.hpp
@@ -2,7 +2,7 @@
 
 #include "ast_node.hpp"
 
-namespace AST {
+namespace ast {
 
 class ReturnStatement : public Node
 {
@@ -16,4 +16,4 @@ public:
     void Print(std::ostream& stream) const override;
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_jump_statement.hpp
+++ b/include/ast_jump_statement.hpp
@@ -10,7 +10,7 @@ private:
     NodePtr expression_;
 
 public:
-    ReturnStatement(Node* expression) : expression_(expression) {}
+    ReturnStatement(NodePtr expression) : expression_(std::move(expression)) {}
 
     void EmitRISC(std::ostream& stream, Context& context) const override;
     void Print(std::ostream& stream) const override;

--- a/include/ast_node.hpp
+++ b/include/ast_node.hpp
@@ -6,7 +6,7 @@
 
 #include "ast_context.hpp"
 
-namespace AST {
+namespace ast {
 
 class Node
 {
@@ -34,4 +34,4 @@ public:
     virtual void Print(std::ostream& stream) const override;
 };
 
-} // namespace AST
+} // namespace ast

--- a/include/ast_node.hpp
+++ b/include/ast_node.hpp
@@ -19,6 +19,7 @@ public:
 // If you don't feel comfortable using std::unique_ptr, you can switch NodePtr to be defined
 // as a raw pointer instead here and your project should still compile, although you'll need
 // to add destructors to avoid leaking memory
+// (and get rid of the now unnecessary std::move-s)
 using NodePtr = std::unique_ptr<const Node>;
 
 class NodeList : public Node

--- a/include/ast_node.hpp
+++ b/include/ast_node.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_NODE_HPP
-#define AST_NODE_HPP
+#pragma once
 
 #include <iostream>
 #include <vector>
@@ -39,5 +38,3 @@ public:
     virtual void EmitRISC(std::ostream &stream, Context &context) const override;
     virtual void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_node.hpp
+++ b/include/ast_node.hpp
@@ -27,9 +27,9 @@ private:
     std::vector<NodePtr> nodes_;
 
 public:
-    NodeList(Node* first_node) { nodes_.emplace_back(first_node); }
+    NodeList(NodePtr first_node) { nodes_.push_back(std::move(first_node)); }
 
-    void PushBack(Node* item);
+    void PushBack(NodePtr item);
     virtual void EmitRISC(std::ostream& stream, Context& context) const override;
     virtual void Print(std::ostream& stream) const override;
 };

--- a/include/ast_node.hpp
+++ b/include/ast_node.hpp
@@ -1,40 +1,35 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <vector>
 
 #include "ast_context.hpp"
 
+namespace AST {
+
 class Node
 {
-protected:
-    std::vector<Node *> branches_;
-
 public:
-    Node(){};
-    virtual ~Node();
-    virtual void EmitRISC(std::ostream &stream, Context &context) const = 0;
-    virtual void Print(std::ostream &stream) const = 0;
+    virtual ~Node() {}
+    virtual void EmitRISC(std::ostream& stream, Context& context) const = 0;
+    virtual void Print(std::ostream& stream) const = 0;
 };
+
+using NodePtr = std::unique_ptr<const Node>;
 
 // Represents a list of nodes.
 class NodeList : public Node
 {
 private:
-    std::vector<Node *> nodes_;
+    std::vector<NodePtr> nodes_;
 
 public:
-    NodeList(Node *first_node) : nodes_({first_node}) {}
+    NodeList(Node* first_node) { nodes_.emplace_back(first_node); }
 
-    ~NodeList()
-    {
-        for (auto node : nodes_)
-        {
-            delete node;
-        }
-    }
-
-    void PushBack(Node *item);
-    virtual void EmitRISC(std::ostream &stream, Context &context) const override;
-    virtual void Print(std::ostream &stream) const override;
+    void PushBack(Node* item);
+    virtual void EmitRISC(std::ostream& stream, Context& context) const override;
+    virtual void Print(std::ostream& stream) const override;
 };
+
+} // namespace AST

--- a/include/ast_node.hpp
+++ b/include/ast_node.hpp
@@ -16,9 +16,11 @@ public:
     virtual void Print(std::ostream& stream) const = 0;
 };
 
+// If you don't feel comfortable using std::unique_ptr, you can switch NodePtr to be defined
+// as a raw pointer instead here and your project should still compile, although you'll need
+// to add destructors to avoid leaking memory
 using NodePtr = std::unique_ptr<const Node>;
 
-// Represents a list of nodes.
 class NodeList : public Node
 {
 private:

--- a/include/ast_type_specifier.hpp
+++ b/include/ast_type_specifier.hpp
@@ -1,15 +1,23 @@
 #pragma once
 
-#include "ast_node.hpp"
+#include <string_view>
+#include <stdexcept>
 
-class TypeSpecifier : public Node
+namespace AST {
+
+enum class TypeSpecifier
 {
-private:
-    std::string type_;
-
-public:
-    TypeSpecifier(std::string type) : type_(type){};
-    ~TypeSpecifier(){};
-    void EmitRISC(std::ostream &stream, Context &context) const override;
-    void Print(std::ostream &stream) const override;
+    INT
 };
+
+constexpr std::string_view ToString(TypeSpecifier type)
+{
+    switch (type)
+    {
+    case TypeSpecifier::INT:
+        return "int";
+    }
+    throw std::runtime_error("Unexpected type specifier");
+}
+
+}

--- a/include/ast_type_specifier.hpp
+++ b/include/ast_type_specifier.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_TYPE_SPECIFIER
-#define AST_TYPE_SPECIFIER
+#pragma once
 
 #include "ast_node.hpp"
 
@@ -14,5 +13,3 @@ public:
     void EmitRISC(std::ostream &stream, Context &context) const override;
     void Print(std::ostream &stream) const override;
 };
-
-#endif

--- a/include/ast_type_specifier.hpp
+++ b/include/ast_type_specifier.hpp
@@ -3,7 +3,7 @@
 #include <string_view>
 #include <stdexcept>
 
-namespace AST {
+namespace ast {
 
 enum class TypeSpecifier
 {

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,5 +1,4 @@
-#ifndef LANGPROC_COMPILER_CLI_H
-#define LANGPROC_COMPILER_CLI_H
+#pragma once
 
 #include <iostream>
 #include <unistd.h>
@@ -11,5 +10,3 @@ struct CommandLineArguments
 };
 
 CommandLineArguments ParseCommandLineArgs(int argc, char **argv);
-
-#endif

--- a/src/ast_constant.cpp
+++ b/src/ast_constant.cpp
@@ -1,11 +1,15 @@
 #include "ast_constant.hpp"
 
-void IntConstant::EmitRISC(std::ostream &stream, Context &context) const
+namespace AST {
+
+void IntConstant::EmitRISC(std::ostream& stream, Context& context) const
 {
     stream << "li a0, " << value_ << std::endl;
 }
 
-void IntConstant::Print(std::ostream &stream) const
+void IntConstant::Print(std::ostream& stream) const
 {
     stream << value_;
 }
+
+} // namespace AST

--- a/src/ast_constant.cpp
+++ b/src/ast_constant.cpp
@@ -1,6 +1,6 @@
 #include "ast_constant.hpp"
 
-namespace AST {
+namespace ast {
 
 void IntConstant::EmitRISC(std::ostream& stream, Context& context) const
 {
@@ -12,4 +12,4 @@ void IntConstant::Print(std::ostream& stream) const
     stream << value_;
 }
 
-} // namespace AST
+} // namespace ast

--- a/src/ast_direct_declarator.cpp
+++ b/src/ast_direct_declarator.cpp
@@ -1,6 +1,6 @@
 #include "ast_direct_declarator.hpp"
 
-namespace AST {
+namespace ast {
 
 void DirectDeclarator::EmitRISC(std::ostream& stream, Context& context) const
 {
@@ -13,4 +13,4 @@ void DirectDeclarator::Print(std::ostream& stream) const
     identifier_->Print(stream);
 }
 
-} // namespace AST
+} // namespace ast

--- a/src/ast_direct_declarator.cpp
+++ b/src/ast_direct_declarator.cpp
@@ -1,12 +1,16 @@
 #include "ast_direct_declarator.hpp"
 
-void DirectDeclarator::EmitRISC(std::ostream &stream, Context &context) const
+namespace AST {
+
+void DirectDeclarator::EmitRISC(std::ostream& stream, Context& context) const
 {
     identifier_->EmitRISC(stream, context);
     stream << ":" << std::endl;
 }
 
-void DirectDeclarator::Print(std::ostream &stream) const
+void DirectDeclarator::Print(std::ostream& stream) const
 {
     identifier_->Print(stream);
 }
+
+} // namespace AST

--- a/src/ast_function_definition.cpp
+++ b/src/ast_function_definition.cpp
@@ -1,6 +1,8 @@
 #include "ast_function_definition.hpp"
 
-void FunctionDefinition::EmitRISC(std::ostream &stream, Context &context) const
+namespace AST {
+
+void FunctionDefinition::EmitRISC(std::ostream& stream, Context& context) const
 {
     // Emit assembler directives.
     // TODO: these are just examples ones, make sure you understand
@@ -16,10 +18,9 @@ void FunctionDefinition::EmitRISC(std::ostream &stream, Context &context) const
     }
 }
 
-void FunctionDefinition::Print(std::ostream &stream) const
+void FunctionDefinition::Print(std::ostream& stream) const
 {
-    declaration_specifiers_->Print(stream);
-    stream << " ";
+    stream << ToString(declaration_specifiers_) << " ";
 
     declarator_->Print(stream);
     stream << "() {" << std::endl;
@@ -29,4 +30,6 @@ void FunctionDefinition::Print(std::ostream &stream) const
         compound_statement_->Print(stream);
     }
     stream << "}" << std::endl;
+}
+
 }

--- a/src/ast_function_definition.cpp
+++ b/src/ast_function_definition.cpp
@@ -1,6 +1,6 @@
 #include "ast_function_definition.hpp"
 
-namespace AST {
+namespace ast {
 
 void FunctionDefinition::EmitRISC(std::ostream& stream, Context& context) const
 {

--- a/src/ast_identifier.cpp
+++ b/src/ast_identifier.cpp
@@ -1,6 +1,6 @@
 #include "ast_identifier.hpp"
 
-namespace AST {
+namespace ast {
 
 void Identifier::EmitRISC(std::ostream& stream, Context& context) const
 {

--- a/src/ast_identifier.cpp
+++ b/src/ast_identifier.cpp
@@ -1,11 +1,15 @@
 #include "ast_identifier.hpp"
 
-void Identifier::EmitRISC(std::ostream &stream, Context &context) const
+namespace AST {
+
+void Identifier::EmitRISC(std::ostream& stream, Context& context) const
 {
     stream << identifier_;
 }
 
-void Identifier::Print(std::ostream &stream) const
+void Identifier::Print(std::ostream& stream) const
 {
     stream << identifier_;
 };
+
+}

--- a/src/ast_jump_statement.cpp
+++ b/src/ast_jump_statement.cpp
@@ -1,6 +1,8 @@
 #include "ast_jump_statement.hpp"
 
-void ReturnStatement::EmitRISC(std::ostream &stream, Context &context) const
+namespace AST {
+
+void ReturnStatement::EmitRISC(std::ostream& stream, Context& context) const
 {
     if (expression_ != nullptr)
     {
@@ -9,7 +11,7 @@ void ReturnStatement::EmitRISC(std::ostream &stream, Context &context) const
     stream << "ret" << std::endl;
 }
 
-void ReturnStatement::Print(std::ostream &stream) const
+void ReturnStatement::Print(std::ostream& stream) const
 {
     stream << "return";
     if (expression_ != nullptr)
@@ -18,4 +20,6 @@ void ReturnStatement::Print(std::ostream &stream) const
         expression_->Print(stream);
     }
     stream << ";" << std::endl;
+}
+
 }

--- a/src/ast_jump_statement.cpp
+++ b/src/ast_jump_statement.cpp
@@ -1,6 +1,6 @@
 #include "ast_jump_statement.hpp"
 
-namespace AST {
+namespace ast {
 
 void ReturnStatement::EmitRISC(std::ostream& stream, Context& context) const
 {

--- a/src/ast_node.cpp
+++ b/src/ast_node.cpp
@@ -2,9 +2,9 @@
 
 namespace ast {
 
-void NodeList::PushBack(Node* item)
+void NodeList::PushBack(NodePtr item)
 {
-    nodes_.emplace_back(item);
+    nodes_.push_back(std::move(item));
 }
 
 void NodeList::EmitRISC(std::ostream& stream, Context& context) const

--- a/src/ast_node.cpp
+++ b/src/ast_node.cpp
@@ -1,6 +1,6 @@
 #include "ast_node.hpp"
 
-namespace AST {
+namespace ast {
 
 void NodeList::PushBack(Node* item)
 {

--- a/src/ast_node.cpp
+++ b/src/ast_node.cpp
@@ -1,21 +1,15 @@
 #include "ast_node.hpp"
 
-Node::~Node()
+namespace AST {
+
+void NodeList::PushBack(Node* item)
 {
-    for (auto branch : branches_)
-    {
-        delete branch;
-    }
+    nodes_.emplace_back(item);
 }
 
-void NodeList::PushBack(Node *item)
+void NodeList::EmitRISC(std::ostream& stream, Context& context) const
 {
-    nodes_.push_back(item);
-}
-
-void NodeList::EmitRISC(std::ostream &stream, Context &context) const
-{
-    for (auto node : nodes_)
+    for (const auto& node : nodes_)
     {
         if (node == nullptr)
         {
@@ -25,9 +19,9 @@ void NodeList::EmitRISC(std::ostream &stream, Context &context) const
     }
 }
 
-void NodeList::Print(std::ostream &stream) const
+void NodeList::Print(std::ostream& stream) const
 {
-    for (auto node : nodes_)
+    for (const auto& node : nodes_)
     {
         if (node == nullptr)
         {
@@ -35,4 +29,6 @@ void NodeList::Print(std::ostream &stream) const
         }
         node->Print(stream);
     }
+}
+
 }

--- a/src/ast_type_specifier.cpp
+++ b/src/ast_type_specifier.cpp
@@ -1,8 +1,0 @@
-#include "ast_type_specifier.hpp"
-
-void TypeSpecifier::EmitRISC(std::ostream &stream, Context &context) const {}
-
-void TypeSpecifier::Print(std::ostream &stream) const
-{
-    stream << type_;
-}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 NodePtr Parse(const CommandLineArguments& args)
 {
     std::cout << "Parsing: " << args.compile_source_path << std::endl;
-    NodePtr root{ ParseAST(args.compile_source_path) };
+    NodePtr root = ParseAST(args.compile_source_path);
     std::cout << "AST parsing complete" << std::endl;
     return root;
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -4,7 +4,7 @@
 #include "cli.h"
 #include "ast.hpp"
 
-using AST::NodePtr;
+using ast::NodePtr;
 
 NodePtr Parse(const CommandLineArguments& args);
 
@@ -59,7 +59,7 @@ void Compile(const NodePtr& root, const CommandLineArguments& args)
 {
     // Create a Context. This can be used to pass around information about
     // what's currently being compiled (e.g. function scope and variable names).
-    AST::Context ctx;
+    ast::Context ctx;
 
     std::cout << "Compiling parsed AST..." << std::endl;
     std::ofstream output(args.compile_output_path, std::ios::trunc);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -4,41 +4,17 @@
 #include "cli.h"
 #include "ast.hpp"
 
-Node *Parse(CommandLineArguments &args)
-{
-    std::cout << "Parsing: " << args.compile_source_path << std::endl;
-    auto root = ParseAST(args.compile_source_path);
-    std::cout << "AST parsing complete" << std::endl;
-    return root;
-}
+using AST::NodePtr;
+
+NodePtr Parse(const CommandLineArguments& args);
 
 // Output the pretty print version of what was parsed to the .printed output
 // file.
-void PrettyPrint(Node *root, CommandLineArguments &args)
-{
-    auto output_path = args.compile_output_path + ".printed";
-
-    std::cout << "Printing parsed AST..." << std::endl;
-    std::ofstream output(output_path, std::ios::trunc);
-    root->Print(output);
-    output.close();
-    std::cout << "Printed parsed AST to: " << output_path << std::endl;
-}
+void PrettyPrint(const NodePtr& root, const CommandLineArguments& args);
 
 // Compile from the root of the AST and output this to the
 // args.compiledOutputPath file.
-void Compile(Node *root, CommandLineArguments &args)
-{
-    // Create a Context. This can be used to pass around information about
-    // what's currently being compiled (e.g. function scope and variable names).
-    Context ctx;
-
-    std::cout << "Compiling parsed AST..." << std::endl;
-    std::ofstream output(args.compile_output_path, std::ios::trunc);
-    root->EmitRISC(output, ctx);
-    output.close();
-    std::cout << "Compiled to: " << args.compile_output_path << std::endl;
-}
+void Compile(const NodePtr& root, const CommandLineArguments& args);
 
 int main(int argc, char **argv)
 {
@@ -58,8 +34,36 @@ int main(int argc, char **argv)
 
     PrettyPrint(ast_root, command_line_arguments);
     Compile(ast_root, command_line_arguments);
+}
 
-    // Clean up afterwards.
-    delete ast_root;
-    return 0;
+NodePtr Parse(const CommandLineArguments& args)
+{
+    std::cout << "Parsing: " << args.compile_source_path << std::endl;
+    NodePtr root{ ParseAST(args.compile_source_path) };
+    std::cout << "AST parsing complete" << std::endl;
+    return root;
+}
+
+void PrettyPrint(const NodePtr& root, const CommandLineArguments& args)
+{
+    auto output_path = args.compile_output_path + ".printed";
+
+    std::cout << "Printing parsed AST..." << std::endl;
+    std::ofstream output(output_path, std::ios::trunc);
+    root->Print(output);
+    output.close();
+    std::cout << "Printed parsed AST to: " << output_path << std::endl;
+}
+
+void Compile(const NodePtr& root, const CommandLineArguments& args)
+{
+    // Create a Context. This can be used to pass around information about
+    // what's currently being compiled (e.g. function scope and variable names).
+    AST::Context ctx;
+
+    std::cout << "Compiling parsed AST..." << std::endl;
+    std::ofstream output(args.compile_output_path, std::ios::trunc);
+    root->EmitRISC(output, ctx);
+    output.close();
+    std::cout << "Compiled to: " << args.compile_output_path << std::endl;
 }

--- a/src/lexer.flex
+++ b/src/lexer.flex
@@ -54,14 +54,14 @@ IS  (u|U|l|L)*
 
 {L}({L}|{D})*		{yylval.string = new std::string(yytext); return(IDENTIFIER);}
 
-0[xX]{H}+{IS}?		{yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
-0{D}+{IS}?		    {yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
-{D}+{IS}?		      {yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
-L?'(\\.|[^\\'])+'	{yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+0[xX]{H}+{IS}?		{yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+0{D}+{IS}?		    {yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+{D}+{IS}?		      {yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+L?'(\\.|[^\\'])+'	{yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
 
-{D}+{E}{FS}?		        {yylval.numberFloat = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
-{D}*"."{D}+({E})?{FS}?	{yylval.numberFloat = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
-{D}+"."{D}*({E})?{FS}?	{yylval.numberFloat = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
+{D}+{E}{FS}?		        {yylval.number_float = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
+{D}*"."{D}+({E})?{FS}?	{yylval.number_float = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
+{D}+"."{D}*({E})?{FS}?	{yylval.number_float = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
 
 L?\"(\\.|[^\\"])*\"	{/* TODO process string literal */; return(STRING_LITERAL);}
 

--- a/src/lexer.flex
+++ b/src/lexer.flex
@@ -54,14 +54,14 @@ IS  (u|U|l|L)*
 
 {L}({L}|{D})*		{yylval.string = new std::string(yytext); return(IDENTIFIER);}
 
-0[xX]{H}+{IS}?		{yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
-0{D}+{IS}?		    {yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
-{D}+{IS}?		      {yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
-L?'(\\.|[^\\'])+'	{yylval.number_int = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+0[xX]{H}+{IS}?		{yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+0{D}+{IS}?		    {yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+{D}+{IS}?		      {yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
+L?'(\\.|[^\\'])+'	{yylval.numberInt = (int)strtol(yytext, NULL, 0); return(INT_CONSTANT);}
 
-{D}+{E}{FS}?		        {yylval.number_float = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
-{D}*"."{D}+({E})?{FS}?	{yylval.number_float = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
-{D}+"."{D}*({E})?{FS}?	{yylval.number_float = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
+{D}+{E}{FS}?		        {yylval.numberFloat = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
+{D}*"."{D}+({E})?{FS}?	{yylval.numberFloat = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
+{D}+"."{D}*({E})?{FS}?	{yylval.numberFloat = strtod(yytext, NULL); return(FLOAT_CONSTANT);}
 
 L?\"(\\.|[^\\"])*\"	{/* TODO process string literal */; return(STRING_LITERAL);}
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -83,7 +83,7 @@ declarator
 
 direct_declarator
 	: IDENTIFIER {
-		$$ = new Identifier(*$1);
+		$$ = new Identifier(std::move(*$1));
 		delete $1;
 	}
 	| direct_declarator '(' ')' {

--- a/src/parser.y
+++ b/src/parser.y
@@ -196,7 +196,7 @@ Node* ParseAST(std::string file_name)
   }
   g_root = nullptr;
   yyparse();
-  yylex_destroy();
   fclose(yyin);
+  yylex_destroy();
   return g_root;
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -7,7 +7,7 @@
 %code requires{
     #include "ast.hpp"
 
-	using namespace AST;
+	using namespace ast;
 
     extern Node* g_root;
     extern FILE* yyin;

--- a/src/parser.y
+++ b/src/parser.y
@@ -18,11 +18,11 @@
 
 %union{
   Node*				node;
-  NodeList*			nodeList;
-  int          		numberInt;
-  double       		numberFloat;
+  NodeList*			node_list;
+  int          		number_int;
+  double       		number_float;
   std::string*		string;
-  TypeSpecifier 	typeSpecifier;
+  TypeSpecifier 	type_specifier;
   yytokentype  		token;
 }
 
@@ -39,12 +39,12 @@
 %type <node> equality_expression and_expression exclusive_or_expression inclusive_or_expression logical_and_expression logical_or_expression
 %type <node> conditional_expression assignment_expression expression declarator direct_declarator statement compound_statement jump_statement
 
-%type <nodeList> statement_list
+%type <node_list> statement_list
 
-%type <numberInt> INT_CONSTANT STRING_LITERAL
-%type <numberFloat> FLOAT_CONSTANT
+%type <number_int> INT_CONSTANT STRING_LITERAL
+%type <number_float> FLOAT_CONSTANT
 %type <string> IDENTIFIER
-%type <typeSpecifier> type_specifier declaration_specifiers
+%type <type_specifier> type_specifier declaration_specifiers
 
 
 %start ROOT

--- a/src/parser.y
+++ b/src/parser.y
@@ -63,7 +63,7 @@ external_declaration
 
 function_definition
 	: declaration_specifiers declarator compound_statement {
-		$$ = new FunctionDefinition($1, $2, $3);
+		$$ = new FunctionDefinition($1, NodePtr($2), NodePtr($3));
 	}
 	;
 
@@ -87,7 +87,7 @@ direct_declarator
 		delete $1;
 	}
 	| direct_declarator '(' ')' {
-		$$ = new DirectDeclarator($1);
+		$$ = new DirectDeclarator(NodePtr($1));
 	}
 	;
 
@@ -100,8 +100,8 @@ compound_statement
 	;
 
 statement_list
-	: statement { $$ = new NodeList($1); }
-	| statement_list statement { $1->PushBack($2); $$=$1; }
+	: statement { $$ = new NodeList(NodePtr($1)); }
+	| statement_list statement { $1->PushBack(NodePtr($2)); $$=$1; }
 	;
 
 jump_statement
@@ -109,7 +109,7 @@ jump_statement
 		$$ = new ReturnStatement(nullptr);
 	}
 	| RETURN expression ';' {
-		$$ = new ReturnStatement($2);
+		$$ = new ReturnStatement(NodePtr($2));
 	}
 	;
 
@@ -187,7 +187,7 @@ expression
 
 Node* g_root;
 
-Node* ParseAST(std::string file_name)
+NodePtr ParseAST(std::string file_name)
 {
   yyin = fopen(file_name.c_str(), "r");
   if(yyin == NULL){
@@ -198,5 +198,5 @@ Node* ParseAST(std::string file_name)
   yyparse();
   fclose(yyin);
   yylex_destroy();
-  return g_root;
+  return NodePtr(g_root);
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -13,6 +13,7 @@
     extern FILE* yyin;
     int yylex(void);
     void yyerror(const char*);
+	int yylex_destroy(void);
 }
 
 %union{
@@ -195,5 +196,7 @@ Node* ParseAST(std::string file_name)
   }
   g_root = nullptr;
   yyparse();
+  yylex_destroy();
+  fclose(yyin);
   return g_root;
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -7,20 +7,22 @@
 %code requires{
     #include "ast.hpp"
 
-    extern Node *g_root;
-    extern FILE *yyin;
+	using namespace AST;
+
+    extern Node* g_root;
+    extern FILE* yyin;
     int yylex(void);
-    void yyerror(const char *);
+    void yyerror(const char*);
 }
 
-// Represents the value associated with any kind of AST node.
 %union{
-  Node         *node;
-  NodeList     *nodes;
-  int          number_int;
-  double       number_float;
-  std::string  *string;
-  yytokentype  token;
+  Node*				node;
+  NodeList*			nodeList;
+  int          		numberInt;
+  double       		numberFloat;
+  std::string*		string;
+  TypeSpecifier 	typeSpecifier;
+  yytokentype  		token;
 }
 
 %token IDENTIFIER INT_CONSTANT FLOAT_CONSTANT STRING_LITERAL
@@ -31,22 +33,17 @@
 %token STRUCT UNION ENUM ELLIPSIS
 %token CASE DEFAULT IF ELSE SWITCH WHILE DO FOR GOTO CONTINUE BREAK RETURN
 
-%type <node> translation_unit external_declaration function_definition primary_expression postfix_expression argument_expression_list
+%type <node> translation_unit external_declaration function_definition primary_expression postfix_expression
 %type <node> unary_expression cast_expression multiplicative_expression additive_expression shift_expression relational_expression
 %type <node> equality_expression and_expression exclusive_or_expression inclusive_or_expression logical_and_expression logical_or_expression
-%type <node> conditional_expression assignment_expression expression constant_expression declaration declaration_specifiers init_declarator_list
-%type <node> init_declarator type_specifier struct_specifier struct_declaration_list struct_declaration specifier_qualifier_list struct_declarator_list
-%type <node> struct_declarator enum_specifier enumerator_list enumerator declarator direct_declarator pointer parameter_list parameter_declaration
-%type <node> identifier_list type_name abstract_declarator direct_abstract_declarator initializer initializer_list statement labeled_statement
-%type <node> compound_statement declaration_list expression_statement selection_statement iteration_statement jump_statement
+%type <node> conditional_expression assignment_expression expression declarator direct_declarator statement compound_statement jump_statement
 
-%type <nodes> statement_list
+%type <nodeList> statement_list
 
-%type <string> unary_operator assignment_operator storage_class_specifier
-
-%type <number_int> INT_CONSTANT STRING_LITERAL
-%type <number_float> FLOAT_CONSTANT
+%type <numberInt> INT_CONSTANT STRING_LITERAL
+%type <numberFloat> FLOAT_CONSTANT
 %type <string> IDENTIFIER
+%type <typeSpecifier> type_specifier declaration_specifiers
 
 
 %start ROOT
@@ -75,7 +72,7 @@ declaration_specifiers
 
 type_specifier
 	: INT {
-		$$ = new TypeSpecifier("int");
+		$$ = TypeSpecifier::INT;
 	}
 	;
 
@@ -123,10 +120,6 @@ primary_expression
 
 postfix_expression
 	: primary_expression
-	;
-
-argument_expression_list
-	: assignment_expression
 	;
 
 unary_expression
@@ -191,9 +184,9 @@ expression
 
 %%
 
-Node *g_root;
+Node* g_root;
 
-Node *ParseAST(std::string file_name)
+Node* ParseAST(std::string file_name)
 {
   yyin = fopen(file_name.c_str(), "r");
   if(yyin == NULL){

--- a/src/parser_full.y.example
+++ b/src/parser_full.y.example
@@ -3,20 +3,24 @@
 %code requires{
     #include "ast.hpp"
 
+	using namespace ast;
+
     extern Node* g_root;
     extern FILE* yyin;
     int yylex(void);
-    void yyerror(const char *);
+    void yyerror(const char*);
+	int yylex_destroy(void);
 }
 
 // Represents the value associated with any kind of AST node.
 %union{
-  Node*        node;
-  NodeList*    nodes;
-  int          number_int;
-  double       number_float;
-  std::string* string;
-  yytokentype  token;
+  Node*        	node;
+  NodeList*    	node_list;
+  int          	number_int;
+  double       	number_float;
+  std::string* 	string;
+  TypeSpecifier	type_specifier;
+  yytokentype  	token;
 }
 
 %token IDENTIFIER INT_CONSTANT FLOAT_CONSTANT STRING_LITERAL
@@ -36,13 +40,16 @@
 %type <node> identifier_list type_name abstract_declarator direct_abstract_declarator initializer initializer_list statement labeled_statement
 %type <node> compound_statement declaration_list expression_statement selection_statement iteration_statement jump_statement
 
-%type <nodes> statement_list
+%type <node_list> statement_list
 
 %type <string> unary_operator assignment_operator storage_class_specifier
 
 %type <number_int> INT_CONSTANT STRING_LITERAL
 %type <number_float> FLOAT_CONSTANT
 %type <string> IDENTIFIER
+%type <type_specifier> type_specifier
+// TODO: Make a better type for this (only needed for advanced features)
+%type <type_specifier> declaration_specifiers
 
 
 %start ROOT
@@ -64,7 +71,7 @@ external_declaration
 function_definition
 	: declaration_specifiers declarator declaration_list compound_statement
 	| declaration_specifiers declarator compound_statement {
-		$$ = new FunctionDefinition($1, $2, $3);
+		$$ = new FunctionDefinition($1, NodePtr($2), NodePtr($3));
 	}
 	| declarator declaration_list compound_statement
 	| declarator compound_statement
@@ -245,9 +252,7 @@ type_specifier
 	: VOID
 	| CHAR
 	| SHORT
-	| INT {
-		$$ = new TypeSpecifier("int");
-	}
+	| INT { $$ = TypeSpecifier::INT; }
 	| LONG
 	| FLOAT
 	| DOUBLE
@@ -312,7 +317,7 @@ declarator
 
 direct_declarator
 	: IDENTIFIER {
-		$$ = new Identifier(*$1);
+		$$ = new Identifier(std::move(*$1));
 		delete $1;
 	}
 	| '(' declarator ')'
@@ -321,7 +326,7 @@ direct_declarator
 	| direct_declarator '(' parameter_list ')'
 	| direct_declarator '(' identifier_list ')'
 	| direct_declarator '(' ')' {
-		$$ = new DirectDeclarator($1);
+		$$ = new DirectDeclarator(NodePtr($1));
 	}
 	;
 
@@ -419,8 +424,8 @@ declaration_list
 	;
 
 statement_list
-	: statement { $$ = new NodeList($1); }
-	| statement_list statement { $1->PushBack($2); $$=$1; }
+	: statement { $$ = new NodeList(NodePtr($1)); }
+	| statement_list statement { $1->PushBack(NodePtr($2)); $$=$1; }
 	;
 
 expression_statement
@@ -449,7 +454,7 @@ jump_statement
 		$$ = new ReturnStatement(nullptr);
 	}
 	| RETURN expression ';' {
-		$$ = new ReturnStatement($2);
+		$$ = new ReturnStatement(NodePtr($2));
 	}
 	;
 
@@ -457,9 +462,9 @@ jump_statement
 
 %%
 
-Node *g_root;
+Node* g_root;
 
-Node *ParseAST(std::string file_name)
+NodePtr ParseAST(std::string file_name)
 {
   yyin = fopen(file_name.c_str(), "r");
   if(yyin == NULL){
@@ -468,5 +473,7 @@ Node *ParseAST(std::string file_name)
   }
   g_root = nullptr;
   yyparse();
-  return g_root;
+  fclose(yyin);
+  yylex_destroy();
+  return NodePtr(g_root);
 }

--- a/src/parser_full.y.example
+++ b/src/parser_full.y.example
@@ -3,19 +3,19 @@
 %code requires{
     #include "ast.hpp"
 
-    extern Node *g_root;
-    extern FILE *yyin;
+    extern Node* g_root;
+    extern FILE* yyin;
     int yylex(void);
     void yyerror(const char *);
 }
 
 // Represents the value associated with any kind of AST node.
 %union{
-  Node         *node;
-  NodeList     *nodes;
+  Node*        node;
+  NodeList*    nodes;
   int          number_int;
   double       number_float;
-  std::string  *string;
+  std::string* string;
   yytokentype  token;
 }
 


### PR DESCRIPTION
**Changes:**
- Replaced old-style `#ifndef` header guards with `#pragma once`
- Wrapped nodes in `AST` namespace - it's in general good practice to do this in projects, and I think it'll help encourage students to do this without being *too* confusing for them.
- Replaced `Node*` stored by nodes to `NodePtr = std::unique_ptr<const Node>`. This change incorporates a couple elements:
  1. Immutability of AST: The AST is constructed by the parser, and all the information a node needs is available once it's constructed. making everything `const` reduces the chances of programmer error
  2. Switch from manual memory management to RAII: Using `new` and `delete` manually is very C-like (/ pre C++11). Although it's all that students are taught in Y1, I think understanding what a `std::unique_ptr` is is relatively straightforward, and encourages students to use a more modern interface.
  3. Aliasing node storage type: by defining `NodePtr` as an alias for the stored type, it not only saves on characters, but makes it much easier for students to switch this type out with something else (like raw pointers) if they find the use of `std::unique_ptr` too confusing.
- `TypeSpecifier` is no longer a `Node` - this makes sense imo because just a type specifier is never enough information for you to produce assembly, meaning that `EmitRISC(...)` will always have an empty / throwing implementation. Also switched to using an `enum class` instead of a `std::string` for hopefully obvious reasons.
- Removed `branches_` from `Node` - see [here](https://edstem.org/us/courses/48687/discussion/4494515?answer=10385823) for reasoning
- Fixed memory leaks - see #21. I'll probably make a separate PR into `main` to fix this since it's minimally invasive and it's kinda unfair to assess students on not leaking memory if we give them a leaky base.
  - Added valgrind to the docker env to make it easier for students to use it
  - [ ] Add docs explaining how to check for memory leaks
  - [ ] Explicitly mention memory management as part of the 10% of marks given for "nice code"
- [nit] (only style change) Changed types from `T &` to `T&` - I think it's much nicer to have the type information all together rather than separated by whitespace (sorry, I couldn't resist)

**Other considered changes:**
- Adding more intermediate abstract classes - in the future, students may need to get information from special types of nodes, for example, getting the name of an identifier. Adding a virtual method to their base node class would be bad practice, as would dynamic casting the member, it would be better for the relevant class to store the derived node type directly / a more specialised abstract class (i.e. `Expression`). Unfortunately, with the basic skeleton we provide, there's no really meaningful intermediate abstract classes we can really provide, for example, we could make `Return` store a pointer to an `Expression` instead of a general node, but currently an `Expression` and a `Node` are exactly the same (it would also make it more difficult for them to switch out the pointer implementation they're using). In general, I'm hoping that `TypeSpecifier` is enough to show them that it's fine for different `Node`s to store things which aren't `Node`s / it's fine for them to add more types to their parser.
- Reducing copying using move semantics - when constructing things like `Identifier`, it would be best practice to use move semantics to avoid copying the string unnecessarily. However, move semantics / r-values is definitely something I'd classify as a more advanced topic, and since we're not really concerned about performance, I don't think there's enough upside to include it to justify the extra burden on the students.