### PR TITLE
point students to main doc (c_compiler.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Repositories
 
 Each group gets a bare private repository. It is up to you if you want to clone the main specification, or to start from scratch.
 
+For an overview of the expected development workflow, usage API, testing format, expected features, and more useful links to get you started, please check out [`c_compiler.md`](docs/c_compiler.md).
+
 Submission
 ==========
 


### PR DESCRIPTION
Just adding one more link to the README, so that students can hopefully get into the docs a bit easier.

Please feel free to close if you think it's unnecessary.

Closes #55 